### PR TITLE
v1.23.0 — Fixed up SCSS imports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.23.0
+------------------------------
+*March 20, 2019*
+
+### Fixed
+- References to `@kickoff/utils.scss` changed to `@justeat/f-utils` in SCSS.
+
+
 v1.22.0
 ------------------------------
 *March 20, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-icons",
   "description": "Common icons for use in Fozzie projects.",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "files": [
     "src"
   ],

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -17,7 +17,7 @@
 /**
  * Imports
  */
-@import 'kickoff-utils'; // imports a set of helper functions and mixins – https://github.com/TryKickoff/kickoff-utils.scss
+@import 'f-utils'; // imports a set of helper functions and mixins – https://github.com/justeat/f-utils
 @import 'include-media'; // Cleaner media query declarations – http://include-media.com
 
 


### PR DESCRIPTION
### Fixed
- References to `@kickoff/utils.scss` changed to `@justeat/f-utils` in SCSS.