### PR TITLE
v2.1.0 - Removing core-js dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.1.0
+------------------------------
+*July 8, 2020*
+
+### Changed
+- Moved `classname` dependency into `devDependencies`.
+- Removed watch flag from test npm script.
+
+### Removed
+- `core-js` dependency and polyfill.
+
+
 v2.0.1
 ------------------------------
 *June 25, 2020*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-icons",
   "description": "Common icons for use in Fozzie projects.",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "dist/f-icons.js",
   "unpkg": "dist/f-icons.min.js",
   "files": [
@@ -29,10 +29,6 @@
     ],
     "testURL": "http://localhost/"
   },
-  "dependencies": {
-    "classnames": "2.2.6",
-    "core-js": "3.6.5"
-  },
   "devDependencies": {
     "@justeat/browserslist-config-fozzie": "1.1.1",
     "@justeat/eslint-config-fozzie": "3.4.1",
@@ -42,6 +38,7 @@
     "babel-preset-stage-2": "6.24.1",
     "cheerio": "1.0.0-rc.2",
     "concurrently": "5.2.0",
+    "classnames": "2.2.6",
     "danger": "10.2.0",
     "eslint": "7.2.0",
     "eslint-plugin-import": "2.21.2",
@@ -63,7 +60,7 @@
     "all": "npm-run-all --sequential build lint test:coverage",
     "build": "./bin/build.sh",
     "lint": "eslint .",
-    "test": "jest --watch",
+    "test": "jest",
     "test:coverage": "jest --coverage",
     "precommit": "lint-staged"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@
 const path = require('path');
 
 module.exports = {
-    entry: ['core-js/es/array/from', path.resolve(__dirname, 'src/index.js')],
+    entry: path.resolve(__dirname, 'src/index.js'),
     output: {
         path: path.resolve(__dirname, 'dist'),
         libraryTarget: 'umd',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2030,11 +2030,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js@3.6.5:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
-  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
-
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"


### PR DESCRIPTION
### Changed
- Moved `classname` dependency into `devDependencies`.
- Removed watch flag from test npm script.

### Removed
- `core-js` dependency and polyfill.