### PR TITLE
v2.5.0 - Remove inline styles from NZ flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.5.0
+------------------------------
+*October 26, 2020*
+
+### Removed
+- Redundant inline style attributes from NZ flag which were causing W3C validation errors.
+
+
 v2.4.0
 ------------------------------
 *October 22, 2020*

--- a/icons/flag.nz.svg
+++ b/icons/flag.nz.svg
@@ -94,17 +94,9 @@
     fill="#fff"
     d="M151.7 0v79.37H0v60.68h151.7v79.37h60.69v-79.37h151.7V79.37H212.4V0z"
     clip-path="url(#flag-nz-a)"
-    color="#000"
-    font-family="sans-serif"
-    font-weight="400"
-    overflow="visible"
   />
   <path
     fill="#cc142b"
     d="M163.84 0v91.5H0v36.41h163.84v91.5h36.41v-91.5H364.1v-36.4H200.25V0z"
-    color="#000"
-    font-family="sans-serif"
-    font-weight="400"
-    overflow="visible"
   />
 </svg>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-icons",
   "description": "Common icons for use in Fozzie projects.",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "main": "dist/f-icons.js",
   "unpkg": "dist/f-icons.min.js",
   "files": [


### PR DESCRIPTION
### Removed
- Redundant inline style attributes from NZ flag which were causing W3C validation errors.